### PR TITLE
[BUGFIX] Remove inclusion of 'rules.neon'

### DIFF
--- a/phpstan.php
+++ b/phpstan.php
@@ -22,9 +22,6 @@ declare(strict_types=1);
  */
 
 return [
-    'includes' => [
-        'rules.neon',
-    ],
     'parameters' => [
         'level' => 'max',
         'paths' => [


### PR DESCRIPTION
Including the `rules.neon` in its own `phpstan.php` configuration had unintended consequences since the `rules.neon` would have been included twice in the projects. This is merely a revert, not an actual fix. 🤷 