### PR TITLE
[BUGFIX] Remove redundantly included `rules.neon`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,8 +40,7 @@
     "extra": {
         "phpstan": {
             "includes": [
-                "extension.neon",
-                "rules.neon"
+                "extension.neon"
             ]
         }
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a339d2d0e39f66aa4b59ee5aa9c48ad1",
+    "content-hash": "81ee2928972b46805bdbb8aac1a97a6c",
     "packages": [
         {
             "name": "ergebnis/phpstan-rules",

--- a/phpstan.php
+++ b/phpstan.php
@@ -22,6 +22,9 @@ declare(strict_types=1);
  */
 
 return [
+    'includes' => [
+        'rules.neon',
+    ],
     'parameters' => [
         'level' => 'max',
         'paths' => [


### PR DESCRIPTION
This PR seeks to fix a bug where the `rules.neon` was included too often.